### PR TITLE
Change references to open-ams repository LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ RadaR can be run locally on protected servers within institutions (for example: 
 RadaR was created at the Faculty of Medical Sciences of the [University of Groningen](https://www.rug.nl/) and the Medical Microbiology & Infection Prevention department of the University Medical Center Groningen (UMCG) by [Christian Luz](https://www.rug.nl/staff/c.f.luz/), PhD Student.
 
 ## Copyright
-[![License](https://img.shields.io/badge/Licence-GPL%20v2.0-orange.svg)](https://github.com/ceefluz/radar/blob/master/LICENSE)
-RadaR is licensed under the [GNU General Public License (GPL) v2.0](https://github.com/ceefluz/radar/blob/master/LICENSE). In a nutshell, this means that this package:
+[![License](https://img.shields.io/badge/Licence-GPL%20v2.0-orange.svg)](https://github.com/open-ams/radar/blob/master/LICENSE)
+RadaR is licensed under the [GNU General Public License (GPL) v2.0](https://github.com/open-ams/radar/blob/master/LICENSE). In a nutshell, this means that this package:
 
 - May be used for commercial purposes
 

--- a/global.R
+++ b/global.R
@@ -2,7 +2,7 @@
 
 # WELCOME TO RadaR
 
-#RadaR is licensed under the GNU General Public License (GPL) v2.0 (https://github.com/ceefluz/radar/blob/master/LICENSE)
+#RadaR is licensed under the GNU General Public License (GPL) v2.0 (https://github.com/open-ams/radar/blob/master/LICENSE)
 
 # INSTALL DEPENDENCIES ----------------------------------------------------
 

--- a/ui.R
+++ b/ui.R
@@ -47,7 +47,7 @@ ui <- dashboardPage(
       a(
         strong("ABOUT RadaR"),
         height = 40,
-        href = "https://github.com/ceefluz/radar/blob/master/README.md",
+        href = "https://github.com/open-ams/radar/blob/master/README.md",
         title = "",
         target = "_blank"
       ),


### PR DESCRIPTION
@ceefluz ,

I'd like to propose to use the open-ams/radar repository as the main github repo.